### PR TITLE
stop geo tracker in error state

### DIFF
--- a/src/Websockettest.js
+++ b/src/Websockettest.js
@@ -90,6 +90,11 @@ function RMBTTest(rmbtTestConfig, rmbtControlServer) {
      * @param {TestState} state
      */
     function setState(state) {
+        if (state == TestState.ERROR) {
+            if (TestEnvironment.getGeoTracker() !== null) {
+                TestEnvironment.getGeoTracker().stop()
+            }
+        }
         if (_state === undefined || _state !== state) {
             _state = state;
             _stateChangeMs = nowMs();


### PR DESCRIPTION
Upon reaching the error state, stop the geo tracker. Prevents it from continueing to run in case of problems.